### PR TITLE
Add Dockerfile for easier testing and deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG PYTHON_VERSION
+ARG PYTHON_VERSION=3.12-slim
 
 FROM python:${PYTHON_VERSION}
 
-ARG CROSSPLANE_VERSION
+ARG CROSSPLANE_VERSION=v1.17.3
 
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+ARG PYTHON_VERSION
+
+FROM python:${PYTHON_VERSION}
+
+ARG CROSSPLANE_VERSION
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | env XP_VERSION="$CROSSPLANE_VERSION" sh && \
+    mv crossplane /usr/local/bin
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    USER=appuser
+
+RUN adduser --disabled-password --gecos "" ${USER}
+
+USER ${USER}
+ENV PATH="/home/${USER}/.local/bin:${PATH}"
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+COPY environment.py .
+
+COPY cucumber_json.py .
+
+COPY steps/ ./steps
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT behave

--- a/environment.py
+++ b/environment.py
@@ -17,8 +17,6 @@ from pathlib import Path
 from behave import fixture, use_fixture
 from behave.runner import Context
 
-COMPOSITION_TESTER_FUNCTIONS_FILE_ON_CI = "COMPOSITION_TESTER_FUNCTIONS_FILE"
-
 @fixture
 def setup_base_path(ctx: Context, feature):
     """Retrieve the base path for the feature file. The base path is the path to the
@@ -89,11 +87,11 @@ def setup_functions_filepath(ctx: Context):
     # By default, functions files are stored in the same directory as the features
     ctx.functions_folder_path = all_features_directory
     if on_ci():
-        # print("Running on CI!")
+        print("Running on CI!")
         ctx.on_ci = True
         # If running on CI, the default functions file is specified by the environment variable "COMPOSITION_TESTER_FUNCTIONS_FILE"
         ci_functions_file = os.environ[
-            COMPOSITION_TESTER_FUNCTIONS_FILE_ON_CI
+            "COMPOSITION_TESTER_FUNCTIONS_FILE"
         ]  # e.g. "functions-ci.yaml"
         functions_filepath = all_features_directory / ci_functions_file
     else:
@@ -155,7 +153,7 @@ def before_feature(context, feature):
 
 def on_ci():
     # check special environment variable to determine if running locally or in CI pipeline (e.g. GITLAB_CI)
-    return COMPOSITION_TESTER_FUNCTIONS_FILE_ON_CI in os.environ
+    return "COMPOSITION_TESTER_FUNCTIONS_FILE" in os.environ
 
 def before_scenario(context: Context, scenario):
     """

--- a/examples/docker/run.sh
+++ b/examples/docker/run.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
+echo "==== Create shared network between functions and crossplane-composition-tester component ===="
 docker network create crossplane-net
 
+echo "=== Network created ===="
+
+echo "=== Launch functions ==="
+echo "=== Launch function-environment-configs ==="
 docker run --network crossplane-net -d --name function-environment-configs xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.1.0 --insecure --address=:9443
+echo "=== Launch function-auto-ready ==="
 docker run --network crossplane-net -d --name function-auto-ready xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0 --insecure --address=:9443
+echo "=== Launch function-go-templating ==="
 docker run --network crossplane-net -d --name function-go-templating xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.7.0 --insecure --address=:9443
 
-docker run --rm --network crossplane-net -v ../test/:/app/test/ -v ../allure-results:/app/allure-results crossplane-composition-tester:v0.0.1 behave test/composition-tests -f allure_behave.formatter:AllureFormatter -o /app/allure-results -f pretty
+echo "Launch crossplane-composition-testser"
+echo "Please update the hostPath folder that contains test"
+docker run --rm --network crossplane-net -v /home/ubuntu/test/:/app/test/ -v /home/ubuntu/allure-results:/app/allure-results benmalekarim/crossplane-composition-tester:v0.0.1 behave test/composition-tests -f allure_behave.formatter:AllureFormatter -o /app/allure-results -f pretty

--- a/examples/docker/run.sh
+++ b/examples/docker/run.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-docker build -t crossplane-composition-tester:v0.0.1 --build-arg PYTHON_VERSION=3.12-slim --build-arg CROSSPLANE_VERSION=v1.17.3 .
-
 docker network create crossplane-net
 
 docker run --network crossplane-net -d --name function-environment-configs xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.1.0 --insecure --address=:9443
 docker run --network crossplane-net -d --name function-auto-ready xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0 --insecure --address=:9443
 docker run --network crossplane-net -d --name function-go-templating xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.7.0 --insecure --address=:9443
 
-docker run --rm --network crossplane-net -v ./test/:/app/test/ -v ./allure-results:/app/allure-results crossplane-composition-tester:v0.0.1 behave test/composition-tests -f allure_behave.formatter:AllureFormatter -o /app/allure-results -f pretty
+docker run --rm --network crossplane-net -v ../test/:/app/test/ -v ../allure-results:/app/allure-results crossplane-composition-tester:v0.0.1 behave test/composition-tests -f allure_behave.formatter:AllureFormatter -o /app/allure-results -f pretty

--- a/examples/kubernetes/crossplane-composition-tester.yaml
+++ b/examples/kubernetes/crossplane-composition-tester.yaml
@@ -20,9 +20,6 @@ spec:
             - "/app/allure-results"
             - "-f"
             - "pretty"
-          envFrom:
-          - configMapRef:
-              name: composition-tester
           volumeMounts:
             - name: test-volume
               mountPath: /app/test

--- a/examples/kubernetes/crossplane-composition-tester.yaml
+++ b/examples/kubernetes/crossplane-composition-tester.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: crossplane-composition-tester
+spec:
+  template:
+    metadata:
+      labels:
+        app: crossplane-composition-tester
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: crossplane-composition-tester
+          image: benmalekarim/crossplane-composition-tester:v0.0.1
+          args:
+            - "test/composition-tests"
+            - "-f"
+            - "allure_behave.formatter:AllureFormatter"
+            - "-o"
+            - "/app/allure-results"
+            - "-f"
+            - "pretty"
+          envFrom:
+          - configMapRef:
+              name: composition-tester
+          volumeMounts:
+            - name: test-volume
+              mountPath: /app/test
+            - name: allure-results-volume
+              mountPath: /app/allure-results
+
+      volumes:
+        - name: test-volume
+          hostPath:
+            path: /home/ubuntu/test   # Replace with the actual path on your host
+            type: Directory
+        - name: allure-results-volume
+          hostPath:
+            path: /home/ubuntu/allure-results  # Replace with actual path
+            type: DirectoryOrCreate

--- a/examples/kubernetes/functions.yaml
+++ b/examples/kubernetes/functions.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: function-auto-ready
           image: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
-          args: ["--insecure", "--address=:9444"]
+          args: ["--insecure", "--address=:9443"]
           ports:
             - containerPort: 9443
 ---

--- a/examples/kubernetes/functions.yaml
+++ b/examples/kubernetes/functions.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: function-environment-configs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: function-environment-configs
+  template:
+    metadata:
+      labels:
+        app: function-environment-configs
+    spec:
+      containers:
+        - name: function-environment-configs
+          image: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.1.0
+          args: ["--insecure", "--address=:9443"]
+          ports:
+            - containerPort: 9443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: function-environment-configs
+spec:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+    name: function-environment-configs
+  selector:
+    app: function-environment-configs
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: function-auto-ready
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: function-auto-ready
+  template:
+    metadata:
+      labels:
+        app: function-auto-ready
+    spec:
+      containers:
+        - name: function-auto-ready
+          image: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
+          args: ["--insecure", "--address=:9444"]
+          ports:
+            - containerPort: 9443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: function-auto-ready
+spec:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+    name: function-auto-ready
+  selector:
+    app: function-auto-ready
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: function-go-templating
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: function-go-templating
+  template:
+    metadata:
+      labels:
+        app: function-go-templating
+    spec:
+      containers:
+        - name: function-go-templating
+          image: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.7.0
+          args: ["--insecure", "--address=:9443"]
+          ports:
+            - containerPort: 9443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: function-go-templating
+spec:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+    name: function-go-templating
+  selector:
+    app: function-go-templating
+  type: ClusterIP

--- a/examples/kubernetes/run.sh
+++ b/examples/kubernetes/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Install functions as deployment and expose them via service"
+kubectl apply -f functions.yaml
+
+echo "Launch crossplane-composition-testser job"
+kubectl apply -f crossplane-composition-tester.yaml

--- a/examples/kubernetes/run.sh
+++ b/examples/kubernetes/run.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-echo "Install functions as deployment and expose them via service"
+echo "=== Install functions as deployment and expose them via service ==="
 kubectl apply -f functions.yaml
 
-echo "Launch crossplane-composition-testser job"
+echo "=== Launch crossplane-composition-testser job ==="
 kubectl apply -f crossplane-composition-tester.yaml
+
+kubectl wait --for=condition=complete job -l app=crossplane-composition-tester
+
+POD_NAME=$(kubectl get pods -l app=crossplane-composition-tester -oname)
+
+echo "=== Get logs of the crossplane-composition-tester"
+kubectl logs $POD_NAME

--- a/examples/test/composition-tests/envconfig.yaml
+++ b/examples/test/composition-tests/envconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: EnvironmentConfig
+metadata:
+  name: envconfig
+data:
+  accountId: "1234"
+  region: "eu-central-1"

--- a/examples/test/composition-tests/functions.yaml
+++ b/examples/test/composition-tests/functions.yaml
@@ -1,0 +1,49 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+  annotations:
+    render.crossplane.io/runtime: Development
+    render.crossplane.io/runtime-development-target: function-go-templating:9443
+    render.crossplane.io/runtime-docker-cleanup: Orphan
+
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.7.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-auto-ready
+  annotations:
+    render.crossplane.io/runtime: Development
+    render.crossplane.io/runtime-development-target: function-auto-ready:9443
+    render.crossplane.io/runtime-docker-cleanup: Orphan
+
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-environment-configs
+  annotations:
+    render.crossplane.io/runtime: Development
+    render.crossplane.io/runtime-development-target: function-environment-configs:9443
+    render.crossplane.io/runtime-docker-cleanup: Orphan
+
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.1.0

--- a/examples/test/composition-tests/service-account-with-functions/resources/claim.yaml
+++ b/examples/test/composition-tests/service-account-with-functions/resources/claim.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: srvaccount.example.com/v1alpha1
+kind: SrvAccount
+metadata:
+  labels:
+    crossplane.io/claim-name: green-demo-sa
+    crossplane.io/claim-namespace: demo
+    crossplane.io/composite: green-demo-sa-vsmvw
+  name: green-demo-sa
+  namespace: demo
+spec:
+  serviceAccountName: green-demo-sa
+  serviceAccountNamespace: demo
+#  policiesARN:
+#    - policyArn1

--- a/examples/test/composition-tests/service-account-with-functions/service-account.feature
+++ b/examples/test/composition-tests/service-account-with-functions/service-account.feature
@@ -1,0 +1,150 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Service Account composition
+  Tests the service account compositions
+
+  Background:
+    Given input claim claim.yaml
+    # following step is optional: default input composition is composition.yaml 
+    And input composition composition.yaml
+    # following step is optional: default input functions is functions.yaml
+    And input functions functions.yaml
+    Then check that no resources are provisioning
+
+  @critical
+  Scenario: service account with default policies
+
+    # render 1
+    When crossplane renders the composition
+    Then check that 2 resources are provisioning
+    And check that resource role has parameters
+      | param name    | param value   |
+      | metadata.name | green-demo-sa |
+    # | spec.forProvider.permissionsBoundary | {regexp}*/sc-policy-cdk-pipeline-permission-boundary |
+
+    # render 2
+    Given change observed resource role with status NOT READY and parameters
+      | param name            | param value |
+      | status.atProvider.arn | arn::role   |
+    And change observed resource default-policy with status NOT READY and parameters
+      | param name            | param value         |
+      | status.atProvider.arn | arn::default-policy |
+    When crossplane renders the composition
+    Then check that 2 resources are provisioning and they are
+      | resource-name  |
+      | role           |
+      | default-policy |
+
+    # render 3
+    Given change observed resource role with status READY
+    And change observed resource default-policy with status READY
+    When crossplane renders the composition
+    Then check that 4 resources are provisioning and they are
+      | resource-name                    |
+      | role                             |
+      | default-policy                   |
+      | green-demo-sa-rpa-default-policy |
+      | green-demo-sa                    |
+    And check that resource green-demo-sa-rpa-default-policy has parameters
+      | param name                | param value   |
+      | spec.forProvider.roleName | green-demo-sa |
+
+    # render 4
+    Given change observed resource green-demo-sa-rpa-default-policy with status READY
+    And change observed resource green-demo-sa with status READY
+    When crossplane renders the composition
+    
+  
+  @normal
+  Scenario: service account with 1 policyARN
+    Given input claim is changed with parameters
+      | param name       | param value      |
+      | spec.policiesARN | \list policyArn1 |
+
+    When crossplane renders the composition
+    Then check that 2 resources are provisioning
+
+    Given change observed resource role with status READY and parameters
+      | param name            | param value |
+      | status.atProvider.arn | arn::role   |
+    And change observed resource default-policy with status READY and parameters
+      | param name            | param value         |
+      | status.atProvider.arn | arn::default-policy |
+    When crossplane renders the composition
+    Then check that 5 resources are provisioning and they are
+      | resource-name                    |
+      | role                             |
+      | default-policy                   |
+      | green-demo-sa-rpa-default-policy |
+      | green-demo-sa-rpa-0              |
+      | green-demo-sa                    |
+    
+    And check that resource green-demo-sa-rpa-0 has parameters
+      | param name                 | param value   |
+      | spec.forProvider.roleName  | green-demo-sa |
+      | spec.forProvider.policyArn | policyArn1    |
+
+    Given change observed resource green-demo-sa-rpa-default-policy with status READY
+    Given change observed resource green-demo-sa-rpa-0 with status READY
+    And change observed resource green-demo-sa with status READY
+    When crossplane renders the composition
+    # Then composite is READY -> depends on the implementation of https://github.com/crossplane/crossplane/issues/4810 in the renderer
+    Then check that 5 resources are provisioning
+
+
+  @minor
+  Scenario: service account with 2 policyARNs
+
+    # render 1
+    Given input claim is changed with parameters
+      | param name       | param value                 |
+      | spec.policiesARN | \list policyArn1,policyArn2 |
+    When crossplane renders the composition
+    Then check that 2 resources are provisioning
+
+    # render 2
+    Given change following observed resources with status READY
+      | resource-name  |
+      | role           |
+      | default-policy |
+    And change observed resource role with parameters
+      | param name            | param value |
+      | status.atProvider.arn | arn::role   |
+    And change observed resource default-policy with parameters
+      | param name            | param value         |
+      | status.atProvider.arn | arn::default-policy |
+    When crossplane renders the composition
+    Then check that 6 resources are provisioning and they are
+      | resource-name                    |
+      | role                             |
+      | default-policy                   |
+      | green-demo-sa-rpa-default-policy |
+      | green-demo-sa-rpa-0              |
+      | green-demo-sa-rpa-1              |
+      | green-demo-sa                    |
+    And check that resource green-demo-sa-rpa-0 has parameters
+      | param name                 | param value   |
+      | spec.forProvider.roleName  | green-demo-sa |
+      | spec.forProvider.policyArn | policyArn1    |
+
+    # render 3
+    Given change all observed resources with status READY
+    When crossplane renders the composition
+    Then log desired resources
+
+    # render 4
+    Given change all observed resources with status NOT READY
+    When crossplane renders the composition
+    Then log desired resources

--- a/examples/test/pkg/service-account-with-functions/composition.yaml
+++ b/examples/test/pkg/service-account-with-functions/composition.yaml
@@ -1,0 +1,260 @@
+# Copyright 2023 Swisscom (Schweiz) AG
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xsrvaccounts.aws.srvaccount.example.com
+spec:
+  compositeTypeRef:
+    apiVersion: srvaccount.example.com/v1alpha1
+    kind: XSrvAccount
+  mode: Pipeline
+  pipeline:
+  - step: environmentConfigs
+    functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - type: Reference
+          ref:
+            name: envconfig
+  - functionRef:
+      name: function-go-templating
+    step: role-and-policies
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |-
+          {{ $accountId:=(index .context "apiextensions.crossplane.io/environment").accountId }}
+          {{ $region:=(index .context "apiextensions.crossplane.io/environment").region }}
+          {{ $eksOID:=(index .context "apiextensions.crossplane.io/environment").eksOID }}
+          {{ $claimName:=(index .observed.composite.resource.metadata.labels "crossplane.io/claim-name") }}
+          {{ $roleName:=$claimName }}
+          {{ $serviceAccountName:=.observed.composite.resource.spec.serviceAccountName }}
+          {{ $serviceAccountNamespace:=.observed.composite.resource.spec.serviceAccountNamespace }}
+
+          ---
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: Role
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: role
+            name: {{$roleName}}
+          spec:
+            forProvider:
+              assumeRolePolicyDocument: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Federated": "arn:aws:iam::{{$accountId}}:oidc-provider/oidc.eks.{{$region}}.amazonaws.com/id/{{$eksOID}}"
+                      },
+                      "Action": "sts:AssumeRoleWithWebIdentity",
+                      "Condition": {
+                        "StringLike": {
+                          "oidc.eks.{{$region}}.amazonaws.com/id/{{$eksOID}}:aud": "sts.amazonaws.com",
+                          "oidc.eks.{{$region}}.amazonaws.com/id/{{$eksOID}}:sub": "system:serviceaccount:{{$serviceAccountNamespace}}:*"
+                        }
+                      }
+                    }
+                  ]
+                }
+              permissionsBoundary: arn:aws:iam::{{$accountId}}:policy/sc-policy-cdk-pipeline-permission-boundary
+            providerConfigRef:
+              name: providerconfig-aws
+          ---
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: Policy
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: default-policy
+          spec:
+            forProvider:
+              name: {{$claimName}}-default-policy
+              document: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Action": [ "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret" ],
+                      "Resource": "arn:aws:secretsmanager:{{$region}}:{{$accountId}}:secret:/all/*"
+                    },
+                    {
+                      "Effect": "Allow",
+                      "Action": [ "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret" ],
+                      "Resource": "arn:aws:secretsmanager:{{$region}}:{{$accountId}}:secret:/{{$serviceAccountName}}/*"
+                    },
+                    {
+                      "Condition": {
+                          "StringEqualsIgnoreCase": {
+                              "aws:ResourceTag/k8s:sa:{{$serviceAccountName}}": "true"
+                          }
+                      },
+                      "Effect": "Allow",
+                      "Action": [ "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret" ],
+                      "Resource": "arn:aws:secretsmanager:{{$region}}:{{$accountId}}:secret:*"
+                    },
+                    {
+                      "Condition": {
+                          "StringEqualsIgnoreCase": {
+                              "aws:ResourceTag/k8s:sa:{{$serviceAccountName}}": "true"
+                          }
+                      },
+                      "Effect": "Allow",
+                      "Action": [ "kms:Decrypt", "kms:DescribeKey" ],
+                      "Resource": "arn:aws:kms:{{$region}}:{{$accountId}}:key/*"
+                    }
+                  ]
+                }
+
+            providerConfigRef:
+              name: providerconfig-aws              
+          ---
+          
+          {{/* Create the custom policies provided in the claim, if they are present */}}
+          {{ range $customPolicy := .observed.composite.resource.spec.customPolicies }}
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: Policy
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: policy-{{$customPolicy.name}}
+          spec:
+            forProvider:
+              name: {{$claimName}}-{{$customPolicy.name}}-policy
+              document: {{ toJson ($customPolicy.policyDocument) }}
+            providerConfigRef:
+              name: providerconfig-aws
+          ---
+          {{ end }}
+
+          {{/* Attach the policies after the role is READY */}}
+
+          {{ if and (ne .observed.resources nil) (ne ( index .observed.resources "role" ) nil) }}
+          {{ if eq (.observed.resources.role | getResourceCondition "Ready").Status "True" }}
+
+          {{/* Attach the policies with ARN from the claim, if they are present */}}
+          {{ with $policiesARN := .observed.composite.resource.spec.policiesARN }}
+          {{ range $policyIndex, $policyArn := $policiesARN }}
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: RolePolicyAttachment
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{$claimName}}-rpa-{{$policyIndex}}
+          spec:
+            forProvider:
+              policyArn: {{$policyArn}}
+              roleName: {{$roleName}}
+            providerConfigRef:
+              name: providerconfig-aws
+          ---
+          {{ end }}
+          {{ end }}
+          
+          {{/* Attach the custom policies from the claim, if they are present */}}
+          {{ range $customPolicy := .observed.composite.resource.spec.customPolicies }}
+          {{ with $customPolicyName := cat "policy-" ($customPolicy.name) }}
+          {{ if and (ne (index .observed.resources $customPolicyName) nil) (eq (index .observed.resources $customPolicyName | getResourceCondition "Ready").Status "True") }}          
+          {{ with $customPolicyArn:=(index .observed.resources $customPolicyName).resource.status.atProvider.arn }}
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: RolePolicyAttachment
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{$claimName}}-rpa-{{$customPolicyName}}
+          spec:
+            forProvider:
+              policyArn: {{$customPolicyArn}}
+              roleName: {{$roleName}}
+            providerConfigRef:
+              name: providerconfig-aws
+          ---
+          {{ end }}
+          {{ end }}
+          {{ end }}
+          {{ end }}
+
+
+          {{/* Attach the default policy after it is READY */}}
+          {{ if and (ne (index .observed.resources "default-policy") nil) (eq (index .observed.resources "default-policy" | getResourceCondition "Ready").Status "True") }}          
+          {{ with $defaultPolicyArn:=(index .observed.resources "default-policy").resource.status.atProvider.arn }}
+          apiVersion: iam.aws.crossplane.io/v1beta1
+          kind: RolePolicyAttachment
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{$claimName}}-rpa-default-policy
+          spec:
+            forProvider:
+              policyArn: {{$defaultPolicyArn}}
+              roleName: {{$roleName}}
+            providerConfigRef:
+              name: providerconfig-aws
+          ---
+          {{ end }}
+          {{ end }}
+
+          {{ end }}
+          {{ end }}
+
+  - functionRef:
+      name: function-go-templating
+    step: service-account
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |-
+          {{ $claimName:=(index .observed.composite.resource.metadata.labels "crossplane.io/claim-name") }}
+          {{ $serviceAccountName:=.observed.composite.resource.spec.serviceAccountName }}
+          {{ $serviceAccountNamespace:=.observed.composite.resource.spec.serviceAccountNamespace }}
+
+          {{/* Wait for the role ARN to be available, then create the service account*/}}
+          {{ if and (ne .observed.resources nil) (ne ( index .observed.resources "role" ) nil) }}
+          {{ if eq (.observed.resources.role | getResourceCondition "Ready").Status "True" }}
+          
+          {{ with $roleArn:=(index .observed.resources "role").resource.status.atProvider.arn }}
+          ---
+          apiVersion: kubernetes.crossplane.io/v1alpha1
+          kind: Object
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{$claimName}}
+          spec:
+            forProvider:
+              manifest:
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  annotations:
+                    eks.amazonaws.com/role-arn: {{$roleArn}}
+                  name: {{$serviceAccountName}}
+                  namespace: {{$serviceAccountNamespace}}
+            providerConfigRef:
+              name: providerconfig-k8s
+          {{ end }}
+
+          {{ end }}
+          {{ end }}
+
+  - step: automatically-detect-ready-composed-resources
+    functionRef:
+      name: function-auto-ready

--- a/examples/test/pkg/service-account-with-functions/definition.yaml
+++ b/examples/test/pkg/service-account-with-functions/definition.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xsrvaccounts.srvaccount.example.com
+spec:
+  group: srvaccount.example.com
+  names:
+    kind: XSrvAccount
+    plural: xsrvaccounts
+  claimNames:
+    kind: SrvAccount
+    plural: srvaccounts
+  enforcedCompositionRef:
+    name: xsrvaccounts.aws.srvaccount.example.com
+  defaultCompositionUpdatePolicy: Automatic
+  defaultCompositeDeletePolicy: Foreground
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                serviceAccountName:
+                  type: string
+                  description: The name of SA
+                serviceAccountNamespace:
+                  type: string
+                  description: The namespace of SA
+                policiesARN:
+                  type: array
+                  description: List of policies ARN to attach
+                  items:
+                    type: string
+              required:
+                - serviceAccountName
+                - serviceAccountNamespace
+            status:
+              type: object
+              properties:
+                record-iteration:
+                  type: integer                

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+docker build -t crossplane-composition-tester:v0.0.1 --build-arg PYTHON_VERSION=3.12-slim --build-arg CROSSPLANE_VERSION=v1.17.3 .
+
+docker network create crossplane-net
+
+docker run --network crossplane-net -d --name function-environment-configs xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.1.0 --insecure --address=:9443
+docker run --network crossplane-net -d --name function-auto-ready xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0 --insecure --address=:9443
+docker run --network crossplane-net -d --name function-go-templating xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.7.0 --insecure --address=:9443
+
+docker run --rm --network crossplane-net -v ./test/:/app/test/ -v ./allure-results:/app/allure-results crossplane-composition-tester:v0.0.1 behave test/composition-tests -f allure_behave.formatter:AllureFormatter -o /app/allure-results -f pretty

--- a/steps/composition_tester.py
+++ b/steps/composition_tester.py
@@ -203,6 +203,7 @@ def render(ctx: Context):
     #  - functions - default ones would be in xplane-pkg repo
     #  - context from the environment file - default ones would be in xplane-pkg repo
 
+    # TODO: Add timeout to render?
 
     # logger.info("rendering composition")
         
@@ -271,8 +272,9 @@ def check_resource_parameters_with_key_prefix(ctx, resource_name, key):
         if key:
             param_name = f"{key}.{param_name}"
 
-        assert_has_resource_entry(
-            resource_name, resource, param_name, value=param_value
+        # TODO: Have support for operators like {regex} or {contains}
+        assert_resource_has_entry(
+            resource_name, resource, param_name, expected=param_value
         )
 
 
@@ -331,8 +333,9 @@ def check_composite_status_parameters(ctx):
         param_name, param_value = row["param name"], row["param value"]
         param_name = f"status.{param_name}"
 
-        assert_has_resource_entry(
-            "composite", desired_xr, param_name, value=param_value
+        # TODO: Have support for operators like {regex} or {contains}
+        assert_resource_has_entry(
+            "composite", desired_xr, param_name, expected=param_value
         )
 
 
@@ -425,6 +428,7 @@ def render_wrong(ctx: Context):
 def log_desired_resources(ctx: Context):
     logger.info("desired resources")
     # log to stdout and attach to allure step
+    # TODO
 
 
 @step("fail here")

--- a/steps/utils/checkers.py
+++ b/steps/utils/checkers.py
@@ -36,8 +36,7 @@ def assert_resource_has_key_and_return_value(resource_name, resource, key: str):
                 f"expected resource {resource_name} to have key {key}")
     return result
 
-
-def assert_has_resource_entry(resource_name, resource, key: str, value: str = None):
+def assert_resource_has_entry(resource_name, resource, key: str, expected: str = ""):
     """Check that a resource has an entry
 
     Arguments:
@@ -46,17 +45,22 @@ def assert_has_resource_entry(resource_name, resource, key: str, value: str = No
         key {str} -- key
 
     Keyword Arguments:
-        value {str} -- value (default: {None})
+        expected {str} -- expected value (default: "")
 
     Raises:
         AssertionError: resource does not have the entry
     """
-    result = str(assert_resource_has_key_and_return_value(
+    value = str(assert_resource_has_key_and_return_value(
         resource_name, resource, key))
-    if value:
-        assert_that(result, equal_to(
-            value), f"expected resource {resource_name} to have {key} with value {value}, but found value {result} instead")
-
+    # For now, 'expected' is always read from feature file test as a string
+    # and 'value' is always read from the yaml (render outupt) as a string
+    # So, we can compare them as strings
+    # If in the future, we preserve the type of values read from yaml, 
+    # uncomment the following line to convert expected to the type of value
+    # expected = parse_value_cmd(expected)
+    
+    if expected is not None:
+        assert_that(value, equal_to(expected), f"expected resource {resource_name} to have key {key} with value {expected}, but found value {value} instead")
 
 def assert_has_not_resource_entry(resource_name, resource, key: str):
     """Check that a resource does not have an entry
@@ -90,7 +94,7 @@ def assert_resource_array_param_has_length(resource_name, resource, key: str, le
         resource_name, resource, key)
 
     assert_that(result, has_length(
-        length), f"expected resource {resource_name} to have {key} with length {length}, but has length {len(result)} instead")
+        length), f"expected resource {resource_name} to have key {key} with length {length}, but has length {len(result)} instead")
 
 
 def check_resources(desired_resources, resource_count: int, expected_resource_names: list[str] = None):

--- a/test/composition-tests/functions.yaml
+++ b/test/composition-tests/functions.yaml
@@ -17,7 +17,10 @@ kind: Function
 metadata:
   name: function-go-templating
   annotations:
-    render.crossplane.io/runtime-docker-cleanup: Stop
+    render.crossplane.io/runtime: Development
+    render.crossplane.io/runtime-development-target: function-go-templating:9443
+    render.crossplane.io/runtime-docker-cleanup: Orphan
+
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.7.0
 ---
@@ -26,7 +29,10 @@ kind: Function
 metadata:
   name: function-auto-ready
   annotations:
-    render.crossplane.io/runtime-docker-cleanup: Stop
+    render.crossplane.io/runtime: Development
+    render.crossplane.io/runtime-development-target: function-auto-ready:9443
+    render.crossplane.io/runtime-docker-cleanup: Orphan
+
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
 ---
@@ -35,6 +41,9 @@ kind: Function
 metadata:
   name: function-environment-configs
   annotations:
-    render.crossplane.io/runtime-docker-cleanup: Stop
+    render.crossplane.io/runtime: Development
+    render.crossplane.io/runtime-development-target: function-environment-configs:9443
+    render.crossplane.io/runtime-docker-cleanup: Orphan
+
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.1.0


### PR DESCRIPTION
- Add Dockerfile to the crossplane test framework to enable packaging it.
- Add usage example using docker and kubernetes.